### PR TITLE
Fix bug where install-creduce.sh is not executed

### DIFF
--- a/framework/docker/Dockerfile
+++ b/framework/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     llvm-14-dbgsym llvm-14-dev-dbgsym llvm-14-tools-dbgsym llvm-14-runtime-dbgsym clang-14-dbgsym valgrind
 
 # The creduce shipped by ubuntu is broken and linked against the wrong LLVM version.
-# THis is just a source rebuild.
+# This is just a source rebuild.
 # In theory we could also rebuild this from source, but it takes a while to
 # build and the debian build system is shit.
 COPY install-creduce.sh /install-creduce.sh

--- a/framework/docker/Dockerfile
+++ b/framework/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
 # In theory we could also rebuild this from source, but it takes a while to
 # build and the debian build system is shit.
 COPY install-creduce.sh /install-creduce.sh
-RUN /install-creduce.sh ; rm /install-creduce.sh
+RUN bash -x /install-creduce.sh ; rm /install-creduce.sh
 
 RUN userdel -r ubuntu && useradd coco -u 1000 -m -s /bin/bash && echo "coco ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN pip3 install --break-system-packages lark llvmlite


### PR DESCRIPTION
The Dockerfile attempts to run the install-creduce shell script as a program, but the git doesn't store it as an executable file. Instead we reuse the solution used earlier in the file to run the script in bash. 