### PR TITLE
Mount the user's gitconfig & ssh directory

### DIFF
--- a/run.py
+++ b/run.py
@@ -6,6 +6,7 @@ import subprocess as sp
 import os
 import socket
 import sys
+import pathlib
 
 if socket.gethostname() == "coco" and getpass.getuser() == "coco":
     print("error: It appears you're already in the docker container.")
@@ -81,6 +82,8 @@ def start():
         args += ["--ulimit", "nofile=10000:10000"]
     # Mount the course folder in the container.
     args += ["--mount", f"type=bind,source={script_dir},target={docker_home_dir}"]
+    # Use the user's git configuration
+    args += "--volume", str(pathlib.Path.home()) + "/.gitconfig:/home/coco/.gitconfig"
     if cmd_args.command:
         args += [image_name]
         args += [shell, "-c", cmd_args.command]

--- a/run.py
+++ b/run.py
@@ -84,6 +84,7 @@ def start():
     args += ["--mount", f"type=bind,source={script_dir},target={docker_home_dir}"]
     # Use the user's git configuration
     args += "--volume", str(pathlib.Path.home()) + "/.gitconfig:/home/coco/.gitconfig"
+    args += "--volume", str(pathlib.Path.home()) + "/.ssh:/home/coco/.ssh"
     if cmd_args.command:
         args += [image_name]
         args += [shell, "-c", cmd_args.command]


### PR DESCRIPTION
This is a local fix that might be useful for the framework, this avoids coco users having to set the email, name and SSH key for git every single time `./run.py` is invoked. 

I don't know what this does on Windows. 