### PR TITLE
Cap optimization score per assignment to 1

### DIFF
--- a/framework/grading/grade_opts.py
+++ b/framework/grading/grade_opts.py
@@ -174,7 +174,8 @@ def grade_optimizations(args):
         try:
             bench = Benchmark(a, t.name, t.path)
             bench.do_benchmark()
-            total_improvements += [bench.get_percentage_improvement()]
+            percentage_improved = bench.get_percentage_improvement()
+            total_improvements += [percentage_improved if percentage_improved <= 1 else 1]
             print(bench.get_score_str())
             if not bench.is_optimized_output_correct():
                 failed_tests += 1


### PR DESCRIPTION
Whenever you overshoot the optimized version from the course, it adds the overperforming score onto your total grade. This okay, except one of mine overperforms* to such an extend that one test causes the script to output a perfect grade on it's own.

This patch caps the total score each individual test can give you to exactly one so that the grading script remains usable. You can also add a higher cap so that students can get some bonus points. 

* I presume that I just got lucky on an aggressive optimization strategy, it is definitely not smarts this time.