### PR TITLE
Make shebangs portable

### DIFF
--- a/assign1/compile.sh
+++ b/assign1/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 

--- a/assign2/optimize.sh
+++ b/assign2/optimize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Note for students: You can skip to the end of this file for the actual
 # optimization pass pipeline. The code inbetween is just boilerplate

--- a/assign3/sanitize.sh
+++ b/assign3/sanitize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$#" -ne 2 ]; then
     echo "Invoke as: $0 INPUT.ll OUTPUT.ll"

--- a/assign4/optimize.sh
+++ b/assign4/optimize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$#" -ne 3 ]; then
     echo "Invoke as: $0 INPUT.ll OUTPUT PassName"

--- a/framework/BIOME/compile-pass.sh
+++ b/framework/BIOME/compile-pass.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 

--- a/framework/codegrade/grade.py
+++ b/framework/codegrade/grade.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 import getpass
 import shutil as sh

--- a/framework/utils/compile-pass.sh
+++ b/framework/utils/compile-pass.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 LLVM_FLAGS=$(llvm-config-14 --cxxflags --libfiles all)
 SO_FLAGS=" -shared -fPIC -g -fsanitize=undefined -fno-sanitize-recover=all -Wno-missing-template-keyword"

--- a/framework/utils/fix-executables.sh
+++ b/framework/utils/fix-executables.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 set -e
 cd "$(dirname "$0")"


### PR DESCRIPTION
Shebangs `#!/bin/bash` are not portable as not all UNIXes have `/bin/bash`, pragmatically only `/bin/sh` is guaranteed to be present, but realistically `/usr/bin/env` is also almost always present. Therefore `#!/usr/bin/env bash` is portable to all UNIXes people care about.