### PR TITLE
Use the `PATH` variable for lookup of binaries, it exists for a reason

### DIFF
--- a/framework/config.json
+++ b/framework/config.json
@@ -1,5 +1,5 @@
 {
   "comment" : "This file contains the paths to opt/clang used in the framework tools",
-  "opt" : "/usr/bin/opt-14",
-  "clang" : "/usr/bin/clang-14"
+  "opt" : "opt-14",
+  "clang" : "clang-14"
 }


### PR DESCRIPTION
Ideally this would also respect `CC`, `CXX` and `OPT` but for now this is fine 